### PR TITLE
Ume evaluation callbacks - switch to Ume tokenizers, expose `evaluate`

### DIFF
--- a/notebooks/04-ume-multimodal-embeddings.ipynb
+++ b/notebooks/04-ume-multimodal-embeddings.ipynb
@@ -11,15 +11,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/zadorozk/Desktop/code/lobster/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/flash_attn/ops/triton/layer_norm.py:984: FutureWarning: `torch.cuda.amp.custom_fwd(args...)` is deprecated. Please use `torch.amp.custom_fwd(args..., device_type='cuda')` instead.\n",
+      "  @custom_fwd\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/flash_attn/ops/triton/layer_norm.py:1043: FutureWarning: `torch.cuda.amp.custom_bwd(args...)` is deprecated. Please use `torch.amp.custom_bwd(args..., device_type='cuda')` instead.\n",
+      "  @custom_bwd\n"
      ]
     },
     {
@@ -49,11 +51,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "checkpoint = \"ume-checkpoints/last.ckpt\" # Replace with the correct checkpoint path\n",
+    "checkpoint = \"ume-checkpoints/best.ckpt\" # Replace with the correct checkpoint path\n",
     "\n",
     "ume = Ume.load_from_checkpoint(checkpoint)"
    ]
@@ -69,15 +71,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Protein embeddings shape: torch.Size([3, 384])\n",
-      "Protein token-level embeddings shape: torch.Size([3, 512, 384])\n"
+      "Protein embeddings shape: torch.Size([3, 768])\n",
+      "Protein token-level embeddings shape: torch.Size([3, 512, 768])\n"
      ]
     }
    ],
@@ -108,14 +110,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "SMILES embeddings shape: torch.Size([5, 384])\n"
+      "SMILES embeddings shape: torch.Size([5, 768])\n"
      ]
     }
    ],
@@ -152,7 +154,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Nucleotide embeddings shape: torch.Size([3, 384])\n"
+      "Nucleotide embeddings shape: torch.Size([3, 768])\n"
      ]
     }
    ],
@@ -179,7 +181,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -201,18 +203,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n",
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n",
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n",
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n",
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Precision and F-score are ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n",
-      "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/sklearn/metrics/_classification.py:1471: UndefinedMetricWarning: Recall and F-score are ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
-      "  _warn_prf(average, modifier, msg_start, len(result))\n"
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Precision is ill-defined and being set to 0.0 in labels with no predicted samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n",
+      "/teamspace/studios/this_studio/lobster/.venv/lib/python3.12/site-packages/sklearn/metrics/_classification.py:1565: UndefinedMetricWarning: Recall is ill-defined and being set to 0.0 in labels with no true samples. Use `zero_division` parameter to control this behavior.\n",
+      "  _warn_prf(average, modifier, f\"{metric.capitalize()} is\", len(result))\n"
      ]
     }
    ],
@@ -240,6 +242,320 @@
     "# Evaluate\n",
     "y_pred = clf.predict(X_test)\n",
     "print(classification_report(y_test, y_pred))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluate on Molecular Property Prediction Tasks\n",
+    "\n",
+    "Here is how to evaluate Ume on tasks defined as callbacks. Note that training on and evaluating these tasks will take a few minutes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "MoleculeACELinearProbeCallback: 100%|██████████| 30/30 [07:58<00:00, 15.94s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from lobster.callbacks import CalmLinearProbeCallback, MoleculeACELinearProbeCallback\n",
+    "\n",
+    "molecule_ace_probe = MoleculeACELinearProbeCallback(\n",
+    "    max_length=ume.embedding_dim\n",
+    ")\n",
+    "molecule_ace_scores = molecule_ace_probe.evaluate(ume)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>CHEMBL238_Ki</th>\n",
+       "      <th>CHEMBL1862_Ki</th>\n",
+       "      <th>CHEMBL237_EC50</th>\n",
+       "      <th>CHEMBL231_Ki</th>\n",
+       "      <th>CHEMBL214_Ki</th>\n",
+       "      <th>CHEMBL4616_EC50</th>\n",
+       "      <th>CHEMBL234_Ki</th>\n",
+       "      <th>CHEMBL228_Ki</th>\n",
+       "      <th>CHEMBL2034_Ki</th>\n",
+       "      <th>CHEMBL233_Ki</th>\n",
+       "      <th>...</th>\n",
+       "      <th>CHEMBL2147_Ki</th>\n",
+       "      <th>CHEMBL218_EC50</th>\n",
+       "      <th>CHEMBL236_Ki</th>\n",
+       "      <th>CHEMBL244_Ki</th>\n",
+       "      <th>CHEMBL2047_EC50</th>\n",
+       "      <th>CHEMBL4203_Ki</th>\n",
+       "      <th>CHEMBL4005_Ki</th>\n",
+       "      <th>CHEMBL204_Ki</th>\n",
+       "      <th>CHEMBL235_EC50</th>\n",
+       "      <th>mean</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>mse</th>\n",
+       "      <td>2.095025</td>\n",
+       "      <td>5.312742</td>\n",
+       "      <td>3.668455</td>\n",
+       "      <td>2.874007</td>\n",
+       "      <td>0.977828</td>\n",
+       "      <td>1.559722</td>\n",
+       "      <td>0.929982</td>\n",
+       "      <td>1.373721</td>\n",
+       "      <td>2.358630</td>\n",
+       "      <td>1.170707</td>\n",
+       "      <td>...</td>\n",
+       "      <td>2.118004</td>\n",
+       "      <td>3.143562</td>\n",
+       "      <td>1.167833</td>\n",
+       "      <td>1.422116</td>\n",
+       "      <td>1.564671</td>\n",
+       "      <td>3.172571</td>\n",
+       "      <td>3.062797</td>\n",
+       "      <td>1.224741</td>\n",
+       "      <td>0.990469</td>\n",
+       "      <td>2.021026</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>r2</th>\n",
+       "      <td>-0.544668</td>\n",
+       "      <td>-1.430170</td>\n",
+       "      <td>-0.756787</td>\n",
+       "      <td>-0.672591</td>\n",
+       "      <td>0.243814</td>\n",
+       "      <td>-0.861025</td>\n",
+       "      <td>0.278650</td>\n",
+       "      <td>0.044004</td>\n",
+       "      <td>-1.337632</td>\n",
+       "      <td>0.312313</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.460752</td>\n",
+       "      <td>-1.877037</td>\n",
+       "      <td>0.349264</td>\n",
+       "      <td>0.454258</td>\n",
+       "      <td>-0.626796</td>\n",
+       "      <td>-1.758412</td>\n",
+       "      <td>-1.626563</td>\n",
+       "      <td>0.476720</td>\n",
+       "      <td>0.145517</td>\n",
+       "      <td>-0.457946</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spearman</th>\n",
+       "      <td>0.473802</td>\n",
+       "      <td>0.539632</td>\n",
+       "      <td>0.380362</td>\n",
+       "      <td>0.486178</td>\n",
+       "      <td>0.546139</td>\n",
+       "      <td>0.273161</td>\n",
+       "      <td>0.608297</td>\n",
+       "      <td>0.501315</td>\n",
+       "      <td>0.387129</td>\n",
+       "      <td>0.602608</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.760325</td>\n",
+       "      <td>0.273797</td>\n",
+       "      <td>0.642653</td>\n",
+       "      <td>0.727715</td>\n",
+       "      <td>0.476775</td>\n",
+       "      <td>0.262011</td>\n",
+       "      <td>0.314889</td>\n",
+       "      <td>0.709204</td>\n",
+       "      <td>0.543911</td>\n",
+       "      <td>0.489678</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>3 rows × 31 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          CHEMBL238_Ki  CHEMBL1862_Ki  CHEMBL237_EC50  CHEMBL231_Ki  \\\n",
+       "mse           2.095025       5.312742        3.668455      2.874007   \n",
+       "r2           -0.544668      -1.430170       -0.756787     -0.672591   \n",
+       "spearman      0.473802       0.539632        0.380362      0.486178   \n",
+       "\n",
+       "          CHEMBL214_Ki  CHEMBL4616_EC50  CHEMBL234_Ki  CHEMBL228_Ki  \\\n",
+       "mse           0.977828         1.559722      0.929982      1.373721   \n",
+       "r2            0.243814        -0.861025      0.278650      0.044004   \n",
+       "spearman      0.546139         0.273161      0.608297      0.501315   \n",
+       "\n",
+       "          CHEMBL2034_Ki  CHEMBL233_Ki  ...  CHEMBL2147_Ki  CHEMBL218_EC50  \\\n",
+       "mse            2.358630      1.170707  ...       2.118004        3.143562   \n",
+       "r2            -1.337632      0.312313  ...       0.460752       -1.877037   \n",
+       "spearman       0.387129      0.602608  ...       0.760325        0.273797   \n",
+       "\n",
+       "          CHEMBL236_Ki  CHEMBL244_Ki  CHEMBL2047_EC50  CHEMBL4203_Ki  \\\n",
+       "mse           1.167833      1.422116         1.564671       3.172571   \n",
+       "r2            0.349264      0.454258        -0.626796      -1.758412   \n",
+       "spearman      0.642653      0.727715         0.476775       0.262011   \n",
+       "\n",
+       "          CHEMBL4005_Ki  CHEMBL204_Ki  CHEMBL235_EC50      mean  \n",
+       "mse            3.062797      1.224741        0.990469  2.021026  \n",
+       "r2            -1.626563      0.476720        0.145517 -0.457946  \n",
+       "spearman       0.314889      0.709204        0.543911  0.489678  \n",
+       "\n",
+       "[3 rows x 31 columns]"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(molecule_ace_scores).head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Generating train split: 5222 examples [00:00, 74980.33 examples/s]\n",
+      "Generating train split: 562 examples [00:00, 37857.53 examples/s]s/it]\n",
+      "Generating train split: 5696 examples [00:00, 151651.71 examples/s]it]\n",
+      "Generating train split: 452 examples [00:00, 21029.68 examples/s]s/it]\n",
+      "Generating train split: 14772 examples [00:00, 125365.49 examples/s]t]\n",
+      "Generating train split: 369 examples [00:00, 23669.81 examples/s]s/it]\n",
+      "CalmLinearProbeCallback: 100%|██████████| 8/8 [02:38<00:00, 19.83s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "calm_probe = CalmLinearProbeCallback(\n",
+    "    max_length=ume.embedding_dim\n",
+    ")\n",
+    "calm_scores = calm_probe.evaluate(ume)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>solubility</th>\n",
+       "      <th>localization</th>\n",
+       "      <th>meltome</th>\n",
+       "      <th>mean</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>mse</th>\n",
+       "      <td>3.649214</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>56.701900</td>\n",
+       "      <td>30.175557</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>r2</th>\n",
+       "      <td>-0.273509</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.464096</td>\n",
+       "      <td>0.095294</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>spearman</th>\n",
+       "      <td>0.038007</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.463611</td>\n",
+       "      <td>0.250809</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>accuracy</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.890833</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.890833</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>f1</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.398531</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0.398531</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          solubility  localization    meltome       mean\n",
+       "mse         3.649214           NaN  56.701900  30.175557\n",
+       "r2         -0.273509           NaN   0.464096   0.095294\n",
+       "spearman    0.038007           NaN   0.463611   0.250809\n",
+       "accuracy         NaN      0.890833        NaN   0.890833\n",
+       "f1               NaN      0.398531        NaN   0.398531"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pd.DataFrame(calm_scores).head()"
    ]
   }
  ],

--- a/src/lobster/callbacks/_calm_linear_probe_callback.py
+++ b/src/lobster/callbacks/_calm_linear_probe_callback.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from collections import defaultdict
-from typing import Optional, Sequence, Tuple
+from typing import Dict, Optional, Sequence, Tuple
 
 import lightning as L
 import numpy as np
@@ -58,17 +58,6 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         Fraction of data to use for testing.
     max_samples : int, default=3000
         Maximum number of samples to use from each dataset.
-    seed : int, default=42
-        Random seed for reproducibility in dataset splitting.
-
-    Attributes
-    ----------
-    dataset_splits : dict
-        Cache of train/test splits for each task.
-    aggregate_metrics : defaultdict
-        Collection of metrics across all tasks for averaging.
-    probes : dict
-        Trained linear probes for each task.
     """
 
     def __init__(
@@ -80,7 +69,6 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         run_every_n_epochs: Optional[int] = None,
         test_size: float = 0.2,
         max_samples: int = 3000,
-        # seed: int = 42,
     ):
         tokenizer_transform = UmeTokenizerTransform(
             modality="nucleotide",
@@ -99,8 +87,6 @@ class CalmLinearProbeCallback(LinearProbeCallback):
 
         self.test_size = test_size
         self.max_samples = max_samples
-        # NOTE zadorozk: see note below
-        # self.seed = seed
 
         self.dataset_splits = {}
         self.aggregate_metrics = defaultdict(list)
@@ -126,10 +112,6 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         split_key = f"{task}_{species}" if species else task
         if split_key in self.dataset_splits:
             return self.dataset_splits[split_key]
-
-        # NOTE zadorozk: this might override the seed set in the trainer
-        # commented out for now, assuming that this is set upstream
-        # L.seed_everything(self.seed)
 
         dataset = CalmPropertyDataset(task=task, species=species, transform_fn=self.transform_fn)
 
@@ -160,11 +142,31 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         task: str,
         train_dataset,
         test_dataset,
-        trainer: L.Trainer,
-        pl_module: L.LightningModule,
-    ):
-        """Evaluate a single task."""
+        model: L.LightningModule,
+        trainer: L.Trainer = None,
+    ) -> Dict[str, float]:
+        """Evaluate a single task.
 
+        Parameters
+        ----------
+        task_key : str
+            The task key for logging (task name or task_species)
+        task : str
+            The actual task name
+        train_dataset : Dataset
+            Training dataset
+        test_dataset : Dataset
+            Test dataset
+        model : Union[L.LightningModule, torch.nn.Module]
+            Model to evaluate
+        trainer : Optional[L.Trainer]
+            Optional trainer for logging
+
+        Returns
+        -------
+        Dict[str, float]
+            Dictionary of metric_name -> value
+        """
         task_type, num_classes = CALM_TASKS[task]
 
         self._set_metrics(task_type, num_classes)
@@ -173,30 +175,55 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         test_loader = DataLoader(test_dataset, batch_size=self.batch_size, shuffle=False)
 
         try:
-            train_embeddings, train_targets = self._get_embeddings(pl_module, train_loader)
-            test_embeddings, test_targets = self._get_embeddings(pl_module, test_loader)
+            train_embeddings, train_targets = self._get_embeddings(model, train_loader)
+            test_embeddings, test_targets = self._get_embeddings(model, test_loader)
 
             probe = self._train_probe(train_embeddings, train_targets)
             self.probes[task_key] = probe
 
             metrics = self._evaluate_probe(probe, test_embeddings, test_targets)
 
-            # Log metrics and store for averaging
-            for metric_name, value in metrics.items():
-                metric_key = f"calm_linear_probe/{task_key}/{metric_name}"
-                trainer.logger.log_metrics({metric_key: value}, step=trainer.current_epoch)
-                self.aggregate_metrics[metric_name].append(value)
+            # Log metrics if trainer is provided
+            if trainer is not None:
+                for metric_name, value in metrics.items():
+                    metric_key = f"calm_linear_probe/{task_key}/{metric_name}"
+                    trainer.logger.log_metrics({metric_key: value})
+
+            return metrics
 
         except Exception as e:
             logger.debug(f"Error in _evaluate_task for {task_key}: {str(e)}")
             raise
 
-    def on_validation_epoch_end(self, trainer: L.Trainer, pl_module: L.LightningModule) -> None:
-        if self._skip(trainer):
-            return
+    def evaluate(
+        self,
+        model: L.LightningModule,
+        trainer: L.Trainer | None = None,
+    ) -> Dict[str, Dict[str, float]]:
+        """Evaluate the model on CALM datasets using linear probes.
 
-        self.device = pl_module.device
-        self.aggregate_metrics.clear()  # Reset aggregation for new epoch
+        This method can be used both during training (with a trainer)
+        and standalone (with just a model).
+
+        Parameters
+        ----------
+        model : Union[L.LightningModule, torch.nn.Module]
+            The model to evaluate
+        trainer : Optional[L.Trainer]
+            Optional trainer for logging metrics
+
+        Returns
+        -------
+        Dict[str, Dict[str, float]]
+            Dictionary of task_name -> metric_name -> value
+        """
+        # Make sure device is set
+        if hasattr(model, "device"):
+            self.device = model.device
+
+        # Clear metrics for this run
+        aggregate_metrics = defaultdict(list)
+        all_task_metrics = {}
 
         for task in tqdm(self.tasks, desc=f"{self.__class__.__name__}"):
             # Handle species-specific tasks
@@ -207,20 +234,54 @@ class CalmLinearProbeCallback(LinearProbeCallback):
                     task_key = f"{task}_{species}"
                     try:
                         train_dataset, test_dataset = self._create_split_datasets(task, species)
-                        self._evaluate_task(task_key, task, train_dataset, test_dataset, trainer, pl_module)
+                        metrics = self._evaluate_task(
+                            task_key,
+                            task,
+                            train_dataset,
+                            test_dataset,
+                            model,
+                            trainer,
+                        )
+                        all_task_metrics[task_key] = metrics
+
+                        # Store for aggregate metrics
+                        for metric_name, value in metrics.items():
+                            aggregate_metrics[metric_name].append(value)
                     except Exception as e:
                         logger.debug(f"Error processing {task_key}: {str(e)}")
             else:
                 try:
                     train_dataset, test_dataset = self._create_split_datasets(task)
-                    self._evaluate_task(task, task, train_dataset, test_dataset, trainer, pl_module)
+                    metrics = self._evaluate_task(
+                        task,
+                        task,
+                        train_dataset,
+                        test_dataset,
+                        model,
+                        trainer,
+                    )
+                    all_task_metrics[task] = metrics
+
+                    # Store for aggregate metrics
+                    for metric_name, value in metrics.items():
+                        aggregate_metrics[metric_name].append(value)
                 except Exception as e:
                     logger.debug(f"Error processing {task}: {str(e)}")
 
         # Calculate and log aggregate metrics
-        for metric_name, values in self.aggregate_metrics.items():
-            if values:  # Only log if we have values
+        mean_metrics = {}
+        for metric_name, values in aggregate_metrics.items():
+            if values:  # Only process if we have values
                 avg_value = sum(values) / len(values)
-                trainer.logger.log_metrics(
-                    {f"calm_linear_probe/mean/{metric_name}": avg_value}, step=trainer.current_epoch
-                )
+                mean_metrics[metric_name] = avg_value
+
+                # Log if trainer is provided
+                if trainer is not None:
+                    trainer.logger.log_metrics(
+                        {f"calm_linear_probe/mean/{metric_name}": avg_value},
+                    )
+
+        # Add mean metrics to the result
+        all_task_metrics["mean"] = mean_metrics
+
+        return all_task_metrics

--- a/src/lobster/callbacks/_calm_linear_probe_callback.py
+++ b/src/lobster/callbacks/_calm_linear_probe_callback.py
@@ -151,7 +151,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         task: str,
         train_dataset,
         test_dataset,
-        model: L.LightningModule,
+        module: L.LightningModule,
         trainer: L.Trainer = None,
     ) -> Dict[str, float]:
         """Evaluate a single task.
@@ -166,7 +166,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
             Training dataset
         test_dataset : Dataset
             Test dataset
-        model : Union[L.LightningModule, torch.nn.Module]
+        module : L.LightningModule
             Model to evaluate
         trainer : Optional[L.Trainer]
             Optional trainer for logging
@@ -184,8 +184,8 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         test_loader = DataLoader(test_dataset, batch_size=self.batch_size, shuffle=False)
 
         try:
-            train_embeddings, train_targets = self._get_embeddings(model, train_loader)
-            test_embeddings, test_targets = self._get_embeddings(model, test_loader)
+            train_embeddings, train_targets = self._get_embeddings(module, train_loader)
+            test_embeddings, test_targets = self._get_embeddings(module, test_loader)
 
             probe = self._train_probe(train_embeddings, train_targets)
             self.probes[task_key] = probe
@@ -206,7 +206,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
 
     def evaluate(
         self,
-        model: L.LightningModule,
+        module: L.LightningModule,
         trainer: L.Trainer | None = None,
     ) -> Dict[str, Dict[str, float]]:
         """Evaluate the model on CALM datasets using linear probes.
@@ -216,7 +216,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
 
         Parameters
         ----------
-        model : Union[L.LightningModule, torch.nn.Module]
+        model : L.LightningModule
             The model to evaluate
         trainer : Optional[L.Trainer]
             Optional trainer for logging metrics
@@ -226,10 +226,6 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         Dict[str, Dict[str, float]]
             Dictionary of task_name -> metric_name -> value
         """
-        # Make sure device is set
-        if hasattr(model, "device"):
-            self.device = model.device
-
         # Clear metrics for this run
         aggregate_metrics = defaultdict(list)
         all_task_metrics = {}
@@ -248,7 +244,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
                             task,
                             train_dataset,
                             test_dataset,
-                            model,
+                            module,
                             trainer,
                         )
                         all_task_metrics[task_key] = metrics
@@ -266,7 +262,7 @@ class CalmLinearProbeCallback(LinearProbeCallback):
                         task,
                         train_dataset,
                         test_dataset,
-                        model,
+                        module,
                         trainer,
                     )
                     all_task_metrics[task] = metrics

--- a/src/lobster/callbacks/_calm_linear_probe_callback.py
+++ b/src/lobster/callbacks/_calm_linear_probe_callback.py
@@ -58,6 +58,15 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         Fraction of data to use for testing.
     max_samples : int, default=3000
         Maximum number of samples to use from each dataset.
+
+    Attributes
+    ----------
+    dataset_splits : dict
+        Cache of train/test splits for each task.
+    aggregate_metrics : defaultdict
+        Collection of metrics across all tasks for averaging.
+    probes : dict
+        Trained linear probes for each task.
     """
 
     def __init__(

--- a/src/lobster/callbacks/_calm_linear_probe_callback.py
+++ b/src/lobster/callbacks/_calm_linear_probe_callback.py
@@ -11,8 +11,7 @@ from tqdm import tqdm
 
 from lobster.constants import CALM_TASKS
 from lobster.datasets import CalmPropertyDataset
-from lobster.tokenization import NucleotideTokenizerFast
-from lobster.transforms import TokenizerTransform
+from lobster.tokenization import UmeTokenizerTransform
 
 from ._linear_probe_callback import LinearProbeCallback
 
@@ -27,6 +26,8 @@ class CalmLinearProbeCallback(LinearProbeCallback):
     prediction tasks from the CALM dataset collection. It creates train/test splits for each task,
     extracts embeddings from the model, trains linear probes on these embeddings, and evaluates
     their performance.
+
+    Currently only supports Ume embeddings and uses UmeTokenizerTransform.
 
     Parameters
     ----------
@@ -81,10 +82,8 @@ class CalmLinearProbeCallback(LinearProbeCallback):
         max_samples: int = 3000,
         # seed: int = 42,
     ):
-        tokenizer_transform = TokenizerTransform(
-            tokenizer=NucleotideTokenizerFast(),
-            padding="max_length",
-            truncation=True,
+        tokenizer_transform = UmeTokenizerTransform(
+            modality="nucleotide",
             max_length=max_length,
         )
 

--- a/src/lobster/callbacks/_linear_probe_callback.py
+++ b/src/lobster/callbacks/_linear_probe_callback.py
@@ -188,7 +188,7 @@ class LinearProbeCallback(Callback):
 
     def evaluate(
         self,
-        model: L.LightningModule,
+        module: L.LightningModule,
         trainer: L.Trainer | None = None,
     ) -> Dict[str, Dict[str, float]]:
         """Evaluate the model using linear probes.
@@ -198,7 +198,7 @@ class LinearProbeCallback(Callback):
 
         Parameters
         ----------
-        model : Union[L.LightningModule, torch.nn.Module]
+        module : L.LightningModule
             The model to evaluate
         trainer : Optional[L.Trainer]
             Optional trainer for logging metrics

--- a/src/lobster/callbacks/_linear_probe_callback.py
+++ b/src/lobster/callbacks/_linear_probe_callback.py
@@ -22,7 +22,13 @@ warnings.filterwarnings(
 
 
 class LinearProbeCallback(Callback):
-    """Callback for evaluating embedding models using scikit-learn linear probes."""
+    """Callback for evaluating embedding models using scikit-learn linear probes.
+
+    Assumes the underlying model is Ume as it accesses
+    `module.model.tokens_to_latents` to extract embeddings. To use with other
+    models, you may need to override `_get_embeddings`.
+
+    """
 
     def __init__(
         self,

--- a/src/lobster/callbacks/_moleculeace_linear_probe_callback.py
+++ b/src/lobster/callbacks/_moleculeace_linear_probe_callback.py
@@ -7,8 +7,7 @@ from tqdm import tqdm
 
 from lobster.constants import MOLECULEACE_TASKS
 from lobster.datasets import MoleculeACEDataset
-from lobster.tokenization import SmilesTokenizerFast
-from lobster.transforms import TokenizerTransform
+from lobster.tokenization import UmeTokenizerTransform
 
 from ._linear_probe_callback import LinearProbeCallback
 
@@ -16,6 +15,8 @@ from ._linear_probe_callback import LinearProbeCallback
 class MoleculeACELinearProbeCallback(LinearProbeCallback):
     """Callback for evaluating embedding models on the Molecule Activity Cliff
     Estimation (MoleculeACE) dataset from Tilborg et al. (2022).
+
+    Currently only supports Ume embeddings and uses UmeTokenizerTransform.
 
     This callback assesses how well a molecular embedding model captures activity
     cliffs - pairs of molecules that are structurally similar but show large
@@ -36,10 +37,8 @@ class MoleculeACELinearProbeCallback(LinearProbeCallback):
         batch_size: int = 32,
         run_every_n_epochs: int | None = None,
     ):
-        tokenizer_transform = TokenizerTransform(
-            tokenizer=SmilesTokenizerFast(),
-            padding="max_length",
-            truncation=True,
+        tokenizer_transform = UmeTokenizerTransform(
+            modality="SMILES",
             max_length=max_length,
         )
 

--- a/src/lobster/callbacks/_moleculeace_linear_probe_callback.py
+++ b/src/lobster/callbacks/_moleculeace_linear_probe_callback.py
@@ -54,7 +54,7 @@ class MoleculeACELinearProbeCallback(LinearProbeCallback):
 
     def evaluate(
         self,
-        model: L.LightningModule,
+        module: L.LightningModule,
         trainer: L.Trainer | None = None,
     ) -> Dict[str, Dict[str, float]]:
         """Evaluate the model on MoleculeACE datasets using linear probes.
@@ -64,7 +64,7 @@ class MoleculeACELinearProbeCallback(LinearProbeCallback):
 
         Parameters
         ----------
-        model : Union[L.LightningModule, torch.nn.Module]
+        module : L.LightningModule
             The model to evaluate
         trainer : Optional[L.Trainer]
             Optional trainer for logging metrics
@@ -74,10 +74,6 @@ class MoleculeACELinearProbeCallback(LinearProbeCallback):
         Dict[str, Dict[str, float]]
             Dictionary of task_name -> metric_name -> value
         """
-        # Make sure device is set
-        if hasattr(model, "device"):
-            self.device = model.device
-
         aggregate_metrics = defaultdict(list)
         all_task_metrics = {}
 
@@ -90,8 +86,8 @@ class MoleculeACELinearProbeCallback(LinearProbeCallback):
 
             try:
                 # Get embeddings
-                train_embeddings, train_targets = self._get_embeddings(model, train_loader)
-                test_embeddings, test_targets = self._get_embeddings(model, test_loader)
+                train_embeddings, train_targets = self._get_embeddings(module, train_loader)
+                test_embeddings, test_targets = self._get_embeddings(module, test_loader)
 
                 # Train probe
                 probe = self._train_probe(train_embeddings, train_targets)

--- a/src/lobster/callbacks/_peer_evaluation_callback.py
+++ b/src/lobster/callbacks/_peer_evaluation_callback.py
@@ -12,8 +12,7 @@ from tqdm import tqdm
 
 from lobster.constants import PEER_TASK_CATEGORIES, PEER_TASK_SPLITS, PEER_TASKS, PEERTask, PEERTaskCategory
 from lobster.datasets import PEERDataset
-from lobster.tokenization import UmeAminoAcidTokenizerFast
-from lobster.transforms import TokenizerTransform
+from lobster.tokenization import UmeTokenizerTransform
 
 from ._linear_probe_callback import LinearProbeCallback
 
@@ -61,6 +60,8 @@ class PEEREvaluationCallback(LinearProbeCallback):
         Guo et al. (2023) "PEER: A Comprehensive and Multi-Task Benchmark for
         Protein Sequence Understanding"
         https://arxiv.org/abs/2206.02096
+
+    Currently only supports Ume embeddings and uses UmeTokenizerTransform.
     """
 
     def __init__(
@@ -83,10 +84,8 @@ class PEEREvaluationCallback(LinearProbeCallback):
         run_every_n_epochs : Optional[int], default=None
             Run this callback every n epochs. If None, runs every validation epoch.
         """
-        tokenizer_transform = TokenizerTransform(
-            tokenizer=UmeAminoAcidTokenizerFast(),
-            padding="max_length",
-            truncation=True,
+        tokenizer_transform = UmeTokenizerTransform(
+            modality="amino_acid",
             max_length=max_length,
         )
 

--- a/src/lobster/data/_ume_datamodule.py
+++ b/src/lobster/data/_ume_datamodule.py
@@ -229,8 +229,8 @@ class UmeLightningDataModule(LightningDataModule):
 
     def _get_dataset_size(self, dataset_info: DatasetInfo, split: Split) -> int:
         if split == Split.TRAIN:
-            if (limit := dataset_info.kwargs.get("limit")) is not None:
-                return limit
+            if dataset_info.kwargs is not None and "limit" in dataset_info.kwargs:
+                return dataset_info.kwargs["limit"]
             else:
                 return dataset_info.train_size
 

--- a/src/lobster/hydra_config/experiment/train_ume.yaml
+++ b/src/lobster/hydra_config/experiment/train_ume.yaml
@@ -7,15 +7,15 @@
 defaults:
   - override /model: ume
   - override /data: ume
-  - override /callbacks: [base, moleculeace_linear_probe_fast, calm_linear_probe_fast]
+  - override /callbacks: [base]
 
 compile: false
 
 data:
   _target_: lobster.data.UmeLightningDataModule
   root: ${oc.env:LOBSTER_DATA_DIR} 
-  datasets: ["M320M", "Calm", "AMPLIFY", "Pinder"]
-  batch_size: 128
+  datasets: ["M320M", "ZINC"]
+  batch_size: 64
   tokenizer_max_length: ${model.max_length}
   pin_memory: true
   shuffle_buffer_size: 1000
@@ -50,7 +50,7 @@ callbacks:
     run_every_n_epochs: 1
 
 logger:
-  name: ume_${model.model_name}_${now:%Y-%m-%d_%H-%M-%S}
+  name: ume_ZINC_M320M_${model.model_name}_${now:%Y-%m-%d_%H-%M-%S}
   project: lobster
   group: ume-dev-${now:%Y-%m-%d-%H-%M-%S}
   entity: ${oc.env:LOBSTER_USER}

--- a/src/lobster/hydra_config/experiment/train_ume.yaml
+++ b/src/lobster/hydra_config/experiment/train_ume.yaml
@@ -50,7 +50,7 @@ callbacks:
     run_every_n_epochs: 1
 
 logger:
-  name: ume_ZINC_M320M_${model.model_name}_${now:%Y-%m-%d_%H-%M-%S}
+  name: ume_${model.model_name}_${now:%Y-%m-%d_%H-%M-%S}
   project: lobster
   group: ume-dev-${now:%Y-%m-%d-%H-%M-%S}
   entity: ${oc.env:LOBSTER_USER}

--- a/tests/lobster/callbacks/test__peer_evaluation_callback.py
+++ b/tests/lobster/callbacks/test__peer_evaluation_callback.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, Mock, patch
 import lightning as L
 import pytest
 import torch
-
 from lobster.callbacks import PEEREvaluationCallback
 from lobster.constants import PEERTask
 
@@ -106,7 +105,7 @@ def mock_transform():
 @pytest.fixture
 def callback(monkeypatch, mock_transform):
     monkeypatch.setattr(
-        "lobster.callbacks._peer_evaluation_callback.TokenizerTransform", lambda **kwargs: mock_transform
+        "lobster.callbacks._peer_evaluation_callback.UmeTokenizerTransform", lambda **kwargs: mock_transform
     )
 
     return PEEREvaluationCallback(


### PR DESCRIPTION
* Switches to UmeTokenizerTransform in evaluation callbacks
* Exposes `evaluate` method outside of Lightning context
```
from lobster.callbacks import MoleculeACELinearProbeCallback

ume = Ume.load_from_checkpoint(...)

probe = MoleculeACELinearProbeCallback(
    max_length=ume.embedding_dim
)
scores = molecule_ace_probe.evaluate(ume)

```

* Updates the notebook example with callback evaluations