### PR TITLE
contrastive retrieval metric

### DIFF
--- a/src/lobster/metrics/__init__.py
+++ b/src/lobster/metrics/__init__.py
@@ -1,4 +1,5 @@
 from ._binary_classification import summarize_binary_classification_metrics
+from ._contrastive_retrieval_accuracy import ContrastiveRetrievalAccuracy
 from ._perturbation_score import PerturbationScore
 from ._random_neighbor_score import RandomNeighborScore
 
@@ -6,4 +7,5 @@ __all__ = [
     "summarize_binary_classification_metrics",
     "RandomNeighborScore",
     "PerturbationScore",
+    "ContrastiveRetrievalAccuracy",
 ]

--- a/src/lobster/metrics/_contrastive_retrieval_accuracy.py
+++ b/src/lobster/metrics/_contrastive_retrieval_accuracy.py
@@ -1,0 +1,248 @@
+import logging
+import random
+from collections.abc import Callable
+from typing import Literal
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torchmetrics import Metric
+
+logger = logging.getLogger(__name__)
+
+
+class ContrastiveRetrievalAccuracy(Metric):
+    """
+    Contrastive Retrieval Accuracy Metric
+
+    This metric measures how well a model can retrieve the correct matching sequence
+    from a different modality given a query sequence. It uses a user-provided transform
+    function to generate pairs of sequences in different modalities (e.g., protein -> SMILES,
+    nucleotide -> amino acid) and then evaluates retrieval accuracy.
+
+    The metric works by:
+    1. Taking a set of query sequences and using the transform function to generate their paired sequences
+    2. For each query, computing embeddings for both query and all candidate sequences
+    3. Ranking candidates by similarity to the query
+    4. Computing top-k retrieval accuracy
+
+    Parameters
+    ----------
+    query_sequences : list[str]
+        List of sequences to use as queries
+    embedding_function : Callable[[list[str], str], Tensor]
+        Function that takes a list of sequences and modality, returns embeddings.
+        Should return tensor of shape (n_sequences, embedding_dim)
+    transform_function : Callable[[str], tuple[str, str | None, str, str]]
+        Function that takes a query sequence and returns a tuple of:
+        (query_sequence, target_sequence, query_modality, target_modality)
+        If transformation fails, target_sequence should be None.
+    k_values : list[int], optional
+        List of k values for top-k accuracy computation. Default is [1, 5, 10].
+    distance_metric : {'cosine', 'euclidean'}, optional
+        Distance metric for similarity computation. Default is 'cosine'.
+    batch_size : int, optional
+        Batch size for processing sequences through the embedding function. Default is 32.
+    random_state : int, optional
+        Random seed for reproducibility. Default is 0.
+
+    Examples
+    --------
+    >>> sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST"]
+    >>> def embedding_fn(seqs, modality):
+    ...     # Your embedding function here
+    ...     return torch.randn(len(seqs), 128)
+    >>> def transform_fn(seq):
+    ...     # Your transform function here - amino acid to SMILES
+    ...     return seq, convert_to_smiles(seq), "amino_acid", "smiles"
+    >>> metric = ContrastiveRetrievalAccuracy(
+    ...     query_sequences=sequences,
+    ...     embedding_function=embedding_fn,
+    ...     transform_function=transform_fn
+    ... )
+    >>> metric.update()
+    >>> results = metric.compute()
+    """
+
+    is_differentiable: bool = False
+    higher_is_better: bool = True
+    full_state_update: bool = False
+
+    def __init__(
+        self,
+        query_sequences: list[str],
+        embedding_function: Callable[[list[str], str], Tensor],
+        transform_function: Callable[[str], tuple[str, str | None, str, str]],
+        k_values: list[int] | None = None,
+        distance_metric: Literal["cosine", "euclidean"] = "cosine",
+        batch_size: int = 32,
+        random_state: int = 0,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        if not query_sequences:
+            raise ValueError("query_sequences cannot be empty")
+
+        self.query_sequences = query_sequences
+        self.embedding_function = embedding_function
+        self.transform_function = transform_function
+        self.k_values = k_values if k_values is not None else [1, 5, 10]
+        self.distance_metric = distance_metric
+        self.batch_size = batch_size
+        self.random_state = random_state
+
+        # Set random seed for reproducibility
+        random.seed(random_state)
+        torch.manual_seed(random_state)
+
+        # Generate pairs during initialization
+        self.query_target_pairs = self._generate_pairs()
+
+        # State for storing retrieval results
+        self.add_state(
+            "retrieval_ranks",
+            default=[],
+            dist_reduce_fx="cat",
+        )
+
+    def _generate_pairs(self) -> list[tuple[str, str, str, str]]:
+        """Generate pairs of sequences using the specified transform function."""
+        pairs = []
+
+        for query_seq in self.query_sequences:
+            try:
+                # Apply transform to get the pair
+                query_result, target_result, query_modality, target_modality = self.transform_function(query_seq)
+
+                # Only add pairs where transformation was successful
+                if target_result is not None:
+                    pairs.append((query_result, target_result, query_modality, target_modality))
+                else:
+                    logger.warning(f"Transform failed for sequence: {query_seq}")
+
+            except Exception as e:
+                logger.warning(f"Error transforming sequence {query_seq}: {e}")
+                continue
+
+        logger.info(f"Generated {len(pairs)} valid pairs out of {len(self.query_sequences)} query sequences")
+        return pairs
+
+    def _process_sequences_in_batches(self, sequences: list[str], modality: str) -> Tensor:
+        """Process a list of sequences through the embedding function in batches."""
+        all_embeddings = []
+
+        for i in range(0, len(sequences), self.batch_size):
+            batch_sequences = sequences[i : i + self.batch_size]
+            batch_embeddings = self.embedding_function(batch_sequences, modality)
+            all_embeddings.append(batch_embeddings)
+
+        return torch.cat(all_embeddings, dim=0)
+
+    def _compute_distances(self, query_embeddings: Tensor, candidate_embeddings: Tensor) -> Tensor:
+        """Compute distances between query and candidate embeddings."""
+        if self.distance_metric == "cosine":
+            query_norm = F.normalize(query_embeddings, p=2, dim=1, eps=1e-8)
+            candidate_norm = F.normalize(candidate_embeddings, p=2, dim=1, eps=1e-8)
+
+            similarity = torch.mm(query_norm, candidate_norm.t())
+            similarity = torch.clamp(similarity, -1.0, 1.0)
+            return 1 - similarity  # Convert similarity to distance
+        else:
+            return torch.cdist(query_embeddings, candidate_embeddings, p=2)
+
+    def update(self) -> None:
+        """
+        Update state with contrastive retrieval analysis results.
+        This method processes the query-target pairs and computes retrieval ranks.
+        """
+        if not self.query_target_pairs:
+            logger.warning("No valid query-target pairs found. Skipping update.")
+            return
+
+        logger.info(f"Running contrastive retrieval analysis on {len(self.query_target_pairs)} pairs")
+
+        # Extract queries, targets, and modalities
+        query_sequences = [pair[0] for pair in self.query_target_pairs]
+        target_sequences = [pair[1] for pair in self.query_target_pairs]
+        query_modalities = [pair[2] for pair in self.query_target_pairs]
+        target_modalities = [pair[3] for pair in self.query_target_pairs]
+
+        # Verify that all query modalities are the same and all target modalities are the same
+        if len(set(query_modalities)) > 1:
+            raise ValueError(f"All query modalities must be the same. Found: {set(query_modalities)}")
+        if len(set(target_modalities)) > 1:
+            raise ValueError(f"All target modalities must be the same. Found: {set(target_modalities)}")
+
+        query_modality = query_modalities[0]
+        target_modality = target_modalities[0]
+
+        logger.info(f"Input modality: {query_modality}, Output modality: {target_modality}")
+
+        # Get embeddings for queries and targets
+        logger.info("Computing embeddings for query sequences...")
+        query_embeddings = self._process_sequences_in_batches(query_sequences, query_modality)
+
+        logger.info("Computing embeddings for target sequences...")
+        target_embeddings = self._process_sequences_in_batches(target_sequences, target_modality)
+
+        # Compute distances between all queries and all targets
+        logger.info("Computing distances...")
+        distances = self._compute_distances(query_embeddings, target_embeddings)
+
+        # For each query, find the rank of its correct target
+        ranks = []
+        for i in range(len(query_sequences)):
+            query_distances = distances[i]  # Distances from query i to all targets
+
+            # Sort distances and find the rank of the correct target (index i)
+            sorted_indices = torch.argsort(query_distances)
+            correct_target_rank = (sorted_indices == i).nonzero(as_tuple=True)[0].item() + 1  # 1-based rank
+            ranks.append(correct_target_rank)
+
+        self.retrieval_ranks.extend(ranks)
+
+        logger.info(f"Computed retrieval ranks for {len(ranks)} queries")
+
+    def compute(self) -> dict[str, float]:
+        """
+        Compute contrastive retrieval accuracy metrics.
+
+        Returns
+        -------
+        dict[str, float]
+            Dictionary containing retrieval accuracy metrics:
+            - top_k_accuracy: Top-k accuracy for each k in k_values
+            - mean_rank: Mean rank of correct retrievals
+            - median_rank: Median rank of correct retrievals
+            - mean_reciprocal_rank: Mean reciprocal rank
+        """
+        if not self.retrieval_ranks:
+            raise ValueError("No retrieval results available. Call update() first.")
+
+        ranks = torch.tensor(self.retrieval_ranks, dtype=torch.float32)
+        n_queries = len(ranks)
+
+        # Compute top-k accuracies
+        results = {}
+        for k in self.k_values:
+            top_k_accuracy = torch.sum(ranks <= k).item() / n_queries
+            results[f"top_{k}_accuracy"] = top_k_accuracy
+
+        # Compute additional metrics
+        results["mean_rank"] = torch.mean(ranks).item()
+        results["median_rank"] = torch.median(ranks).item()
+        results["mean_reciprocal_rank"] = torch.mean(1.0 / ranks).item()
+
+        # Log results
+        logger.info("Contrastive Retrieval Accuracy Results:")
+        for k in self.k_values:
+            logger.info(f"  Top-{k} accuracy: {results[f'top_{k}_accuracy']:.3f}")
+        logger.info(f"  Mean rank: {results['mean_rank']:.3f}")
+        logger.info(f"  Median rank: {results['median_rank']:.3f}")
+        logger.info(f"  Mean reciprocal rank: {results['mean_reciprocal_rank']:.3f}")
+
+        # Reset state
+        self.retrieval_ranks.clear()
+
+        return results

--- a/tests/lobster/metrics/test_contrastive_retrieval_accuracy.py
+++ b/tests/lobster/metrics/test_contrastive_retrieval_accuracy.py
@@ -1,0 +1,476 @@
+import pytest
+import torch
+from torch import Tensor
+
+from lobster.metrics import ContrastiveRetrievalAccuracy
+from lobster.transforms import (
+    AminoAcidToSmilesPairTransform,
+    NucleotideToAminoAcidPairTransform,
+    SmilesToSmilesPairTransform,
+)
+
+
+def dummy_embedding_function(sequences: list[str], modality: str) -> Tensor:
+    """Dummy embedding function that returns random embeddings."""
+    return torch.randn(len(sequences), 64)
+
+
+def create_amino_acid_to_smiles_transform():
+    """Create a transform function for amino acid to SMILES conversion."""
+    transform = AminoAcidToSmilesPairTransform()
+
+    def transform_function(seq: str) -> tuple[str, str | None, str, str]:
+        try:
+            result = transform._transform(seq, {})
+            return result[0], result[1], "amino_acid", "smiles"
+        except Exception:
+            return seq, None, "amino_acid", "smiles"
+
+    return transform_function
+
+
+def create_nucleotide_to_amino_acid_transform():
+    """Create a transform function for nucleotide to amino acid conversion."""
+    transform = NucleotideToAminoAcidPairTransform()
+
+    def transform_function(seq: str) -> tuple[str, str | None, str, str]:
+        try:
+            result = transform._transform(seq, {})
+            return result[0], result[1], "nucleotide", "amino_acid"
+        except Exception:
+            return seq, None, "nucleotide", "amino_acid"
+
+    return transform_function
+
+
+def create_smiles_to_smiles_transform():
+    """Create a transform function for SMILES to SMILES conversion."""
+    transform = SmilesToSmilesPairTransform(randomize_smiles=True)
+
+    def transform_function(seq: str) -> tuple[str, str | None, str, str]:
+        try:
+            result = transform._transform(seq, {})
+            return result[0], result[1], "smiles", "smiles"
+        except Exception:
+            return seq, None, "smiles", "smiles"
+
+    return transform_function
+
+
+def create_custom_length_transform():
+    """Create a custom transform function that maps sequences to their length categories."""
+
+    def transform_function(seq: str) -> tuple[str, str | None, str, str]:
+        length = len(seq)
+        if length <= 5:
+            category = "short"
+        elif length <= 10:
+            category = "medium"
+        else:
+            category = "long"
+        return seq, category, "sequence", "length_category"
+
+    return transform_function
+
+
+def test_contrastive_retrieval_accuracy_init():
+    """Test initialization of ContrastiveRetrievalAccuracy metric."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST"]
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1, 5],
+        distance_metric="cosine",
+        batch_size=16,
+        random_state=42,
+    )
+
+    assert metric.query_sequences == sequences
+    assert metric.transform_function == transform_fn
+    assert metric.k_values == [1, 5]
+    assert metric.distance_metric == "cosine"
+    assert metric.batch_size == 16
+    assert metric.random_state == 42
+    assert hasattr(metric, "query_target_pairs")
+
+
+def test_contrastive_retrieval_accuracy_init_empty_sequences():
+    """Test that empty sequences raise ValueError."""
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    with pytest.raises(ValueError, match="query_sequences cannot be empty"):
+        ContrastiveRetrievalAccuracy(
+            query_sequences=[], embedding_function=dummy_embedding_function, transform_function=transform_fn
+        )
+
+
+def test_contrastive_retrieval_accuracy_invalid_transform():
+    """Test that invalid transform function raises appropriate error."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+
+    def invalid_transform(seq: str) -> tuple[str, str | None, str, str]:
+        raise ValueError("Invalid transform")
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=invalid_transform,
+        random_state=42,
+    )
+
+    # The metric should handle the error gracefully and have empty pairs
+    assert len(metric.query_target_pairs) == 0
+
+
+def test_contrastive_retrieval_accuracy_compute_without_update():
+    """Test that compute without update raises ValueError."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        random_state=42,
+    )
+
+    with pytest.raises(ValueError, match="No retrieval results available"):
+        metric.compute()
+
+
+def test_contrastive_retrieval_accuracy_perfect_embedding():
+    """Test metric with perfect embedding function (identity mapping)."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST"]
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    def perfect_embedding_function(sequences: list[str], modality: str) -> Tensor:
+        """Perfect embedding function that returns identical embeddings for paired sequences."""
+        # For simplicity, return embeddings based on sequence length
+        embeddings = []
+        for seq in sequences:
+            # Create embedding based on sequence characteristics
+            embedding = torch.zeros(64)
+            embedding[0] = len(seq)  # First dimension encodes length
+            # Add some sequence-specific features
+            for i, char in enumerate(seq[:10]):  # Use first 10 chars
+                embedding[i + 1] = ord(char) / 100.0
+            embeddings.append(embedding)
+        return torch.stack(embeddings)
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=perfect_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1, 3, 5],
+        random_state=42,
+    )
+
+    # Update and compute
+    metric.update()
+    results = metric.compute()
+
+    # Check that results contain expected keys
+    assert "top_1_accuracy" in results
+    assert "top_3_accuracy" in results
+    assert "top_5_accuracy" in results
+    assert "mean_rank" in results
+    assert "median_rank" in results
+    assert "mean_reciprocal_rank" in results
+
+    # Check that all values are reasonable
+    assert 0 <= results["top_1_accuracy"] <= 1
+    assert 0 <= results["top_3_accuracy"] <= 1
+    assert 0 <= results["top_5_accuracy"] <= 1
+    assert results["mean_rank"] >= 1
+    assert results["median_rank"] >= 1
+    assert 0 <= results["mean_reciprocal_rank"] <= 1
+
+
+@pytest.mark.parametrize(
+    "transform_type,sequences",
+    [
+        ("amino_acid_to_smiles", ["MKLLVVVGG", "ARNDCQEGH"]),
+        ("nucleotide_to_amino_acid", ["ATGAAACTGCTG", "ATGGGCAAATAA"]),
+        ("smiles_to_smiles", ["CCO", "CC(=O)O"]),
+    ],
+)
+def test_contrastive_retrieval_accuracy_different_transforms(transform_type, sequences):
+    """Test metric with different transform types."""
+    # Get the appropriate transform function
+    if transform_type == "amino_acid_to_smiles":
+        transform_fn = create_amino_acid_to_smiles_transform()
+    elif transform_type == "nucleotide_to_amino_acid":
+        transform_fn = create_nucleotide_to_amino_acid_transform()
+    elif transform_type == "smiles_to_smiles":
+        transform_fn = create_smiles_to_smiles_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1, 2],
+        random_state=42,
+    )
+
+    # Check that the metric initializes correctly
+    assert metric.transform_function == transform_fn
+    assert len(metric.query_target_pairs) >= 0  # Some transforms might fail
+
+
+@pytest.mark.parametrize("distance_metric", ["cosine", "euclidean"])
+def test_contrastive_retrieval_accuracy_distance_metrics(distance_metric):
+    """Test metric with different distance metrics."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        distance_metric=distance_metric,
+        random_state=42,
+    )
+
+    assert metric.distance_metric == distance_metric
+
+    # Update and compute
+    metric.update()
+
+    # Only compute if we have valid pairs
+    if metric.retrieval_ranks:
+        results = metric.compute()
+        assert isinstance(results, dict)
+
+
+def test_contrastive_retrieval_accuracy_batch_processing():
+    """Test metric with small batch size to verify batch processing."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST", "ALANYLGLY"]
+    transform_fn = create_amino_acid_to_smiles_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        batch_size=2,  # Small batch size
+        random_state=42,
+    )
+
+    # Update and compute
+    metric.update()
+
+    # Only compute if we have valid pairs
+    if metric.retrieval_ranks:
+        results = metric.compute()
+        assert isinstance(results, dict)
+
+
+def test_contrastive_retrieval_accuracy_reproducibility():
+    """Test that the metric produces reproducible results."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST"]
+    transform_fn1 = create_amino_acid_to_smiles_transform()
+    transform_fn2 = create_amino_acid_to_smiles_transform()
+
+    # Run metric twice with same random state
+    metric1 = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn1,
+        random_state=42,
+    )
+
+    metric2 = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn2,
+        random_state=42,
+    )
+
+    # Both should generate the same pairs
+    metric1.update()
+    metric2.update()
+
+    # Check that the number of pairs is the same
+    assert len(metric1.query_target_pairs) == len(metric2.query_target_pairs)
+
+
+def test_contrastive_retrieval_accuracy_custom_transform():
+    """Test metric with a completely custom transform function."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST", "ACDEF", "VWKSTMNPQFIL"]
+    transform_fn = create_custom_length_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1, 2, 3],
+        random_state=42,
+    )
+
+    # All sequences should be transformed successfully
+    assert len(metric.query_target_pairs) == len(sequences)
+
+    # Check that modalities are correct
+    for pair in metric.query_target_pairs:
+        assert pair[2] == "sequence"  # query modality
+        assert pair[3] == "length_category"  # target modality
+
+    # Update and compute
+    metric.update()
+    results = metric.compute()
+
+    # Check results structure
+    assert "top_1_accuracy" in results
+    assert "top_2_accuracy" in results
+    assert "top_3_accuracy" in results
+    assert "mean_rank" in results
+    assert "median_rank" in results
+    assert "mean_reciprocal_rank" in results
+
+
+def test_contrastive_retrieval_accuracy_mixed_query_modalities_error():
+    """Test that mixed query modalities in pairs raise an error."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+
+    def mixed_query_modality_transform(seq: str) -> tuple[str, str | None, str, str]:
+        # Return different query modalities for different sequences
+        if seq == "MKLLVVVGG":
+            return seq, "CCO", "amino_acid", "smiles"
+        else:
+            return seq, "short", "sequence", "smiles"
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=mixed_query_modality_transform,
+        random_state=42,
+    )
+
+    # This should raise an error during update because of mixed query modalities
+    with pytest.raises(ValueError, match="All query modalities must be the same"):
+        metric.update()
+
+
+def test_contrastive_retrieval_accuracy_mixed_target_modalities_error():
+    """Test that mixed target modalities in pairs raise an error."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+
+    def mixed_target_modality_transform(seq: str) -> tuple[str, str | None, str, str]:
+        # Return different target modalities for different sequences
+        if seq == "MKLLVVVGG":
+            return seq, "CCO", "amino_acid", "smiles"
+        else:
+            return seq, "short", "amino_acid", "length_category"
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=mixed_target_modality_transform,
+        random_state=42,
+    )
+
+    # This should raise an error during update because of mixed target modalities
+    with pytest.raises(ValueError, match="All target modalities must be the same"):
+        metric.update()
+
+
+def test_contrastive_retrieval_accuracy_no_valid_pairs():
+    """Test behavior when no valid pairs are generated."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH"]
+
+    def failing_transform(seq: str) -> tuple[str, str | None, str, str]:
+        return seq, None, "amino_acid", "smiles"  # Always return None for target
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=failing_transform,
+        random_state=42,
+    )
+
+    # Should have no valid pairs
+    assert len(metric.query_target_pairs) == 0
+
+    # Update should handle this gracefully
+    metric.update()  # Should not raise an error
+
+    # Compute should still raise an error since no pairs were processed
+    with pytest.raises(ValueError, match="No retrieval results available"):
+        metric.compute()
+
+
+def test_contrastive_retrieval_accuracy_k_values():
+    """Test metric with different k values."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST", "ALANYLGLY"]
+    transform_fn = create_custom_length_transform()
+
+    # Test with custom k values
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1, 2, 4],
+        random_state=42,
+    )
+
+    assert metric.k_values == [1, 2, 4]
+
+    metric.update()
+    results = metric.compute()
+
+    # Should have results for all specified k values
+    assert "top_1_accuracy" in results
+    assert "top_2_accuracy" in results
+    assert "top_4_accuracy" in results
+    assert "top_3_accuracy" not in results  # Should not have k=3
+
+
+def test_contrastive_retrieval_accuracy_single_sequence():
+    """Test metric with a single sequence."""
+    sequences = ["MKLLVVVGG"]
+    transform_fn = create_custom_length_transform()
+
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        k_values=[1],
+        random_state=42,
+    )
+
+    assert len(metric.query_target_pairs) == 1
+
+    metric.update()
+    results = metric.compute()
+
+    # With a single sequence, top-1 accuracy should be 1.0 (perfect retrieval)
+    assert results["top_1_accuracy"] == 1.0
+    assert results["mean_rank"] == 1.0
+    assert results["median_rank"] == 1.0
+    assert results["mean_reciprocal_rank"] == 1.0
+
+
+def test_contrastive_retrieval_accuracy_default_k_values():
+    """Test metric with default k values."""
+    sequences = ["MKLLVVVGG", "ARNDCQEGH", "FILVYWKST"]
+    transform_fn = create_custom_length_transform()
+
+    # Test with default k values (should be [1, 5, 10])
+    metric = ContrastiveRetrievalAccuracy(
+        query_sequences=sequences,
+        embedding_function=dummy_embedding_function,
+        transform_function=transform_fn,
+        random_state=42,
+    )
+
+    assert metric.k_values == [1, 5, 10]
+
+    metric.update()
+    results = metric.compute()
+
+    # Should have results for default k values
+    assert "top_1_accuracy" in results
+    assert "top_5_accuracy" in results
+    assert "top_10_accuracy" in results


### PR DESCRIPTION
## Description

Added a new ContrastiveRetrievalAccuracy metric for measuring cross-modal retrieval performance in biological sequence models. The metric supports custom transform functions to generate query-target pairs across different modalities (e.g., protein sequences to SMILES) and computes retrieval metrics including top-k accuracy, mean rank, median rank, and mean reciprocal rank.

## Type of Change
- [ ] Bug fix
- [x] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [x] Tests pass locally
- [x] Added new tests for new functionality
- [ ] Updated existing tests if needed

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)