### PR TITLE
cpu attn mask

### DIFF
--- a/src/lobster/model/_ume.py
+++ b/src/lobster/model/_ume.py
@@ -439,27 +439,27 @@ class UME(L.LightningModule):
         if self.model.config.padding == "unpadded":
             embeddings = embeddings.view(batch_size, seq_len, -1)
 
+        # Handle attention mask for both aggregated and token-level outputs
+        attention_mask = x["attention_mask"]
+        if attention_mask.dim() == 3:
+            attention_mask = attention_mask.squeeze(1)  # Remove middle dimension: (batch, seq_len)
+
+        # Ensure attention mask matches embedding sequence length
+        if attention_mask.shape[1] != embeddings.shape[1]:
+            # Truncate or pad attention mask to match embeddings
+            if attention_mask.shape[1] > embeddings.shape[1]:
+                attention_mask = attention_mask[:, : embeddings.shape[1]]
+            else:
+                pad_length = embeddings.shape[1] - attention_mask.shape[1]
+                padding = torch.zeros(
+                    attention_mask.shape[0], pad_length, dtype=attention_mask.dtype, device=attention_mask.device
+                )
+                attention_mask = torch.cat([attention_mask, padding], dim=1)
+
+        # Convert to float and add dimension for broadcasting: (batch, seq_len, 1)
+        mask = attention_mask.float().unsqueeze(-1)
+
         if aggregate:
-            # Use attention mask to exclude padding tokens from mean pooling
-            attention_mask = x["attention_mask"]
-            if attention_mask.dim() == 3:
-                attention_mask = attention_mask.squeeze(1)  # Remove middle dimension: (batch, seq_len)
-
-            # Ensure attention mask matches embedding sequence length
-            if attention_mask.shape[1] != embeddings.shape[1]:
-                # Truncate or pad attention mask to match embeddings
-                if attention_mask.shape[1] > embeddings.shape[1]:
-                    attention_mask = attention_mask[:, : embeddings.shape[1]]
-                else:
-                    pad_length = embeddings.shape[1] - attention_mask.shape[1]
-                    padding = torch.zeros(
-                        attention_mask.shape[0], pad_length, dtype=attention_mask.dtype, device=attention_mask.device
-                    )
-                    attention_mask = torch.cat([attention_mask, padding], dim=1)
-
-            # Convert to float and add dimension for broadcasting: (batch, seq_len, 1)
-            mask = attention_mask.float().unsqueeze(-1)
-
             # Apply mask and compute mean only over actual tokens
             masked_embeddings = embeddings * mask
             sum_embeddings = masked_embeddings.sum(dim=1)  # (batch, hidden_dim)
@@ -468,6 +468,10 @@ class UME(L.LightningModule):
             # Avoid division by zero for empty sequences
             token_counts = torch.clamp(token_counts, min=1.0)
             embeddings = sum_embeddings / token_counts
+        else:
+            # For token-level embeddings, zero out padding token positions
+            # This ensures consistency between flash attention and non-flash attention models
+            embeddings = embeddings * mask
 
         return embeddings
 


### PR DESCRIPTION
## Description
This pull request introduces significant improvements to the embedding computation in the `UME` model and adds comprehensive tests to ensure consistency across different configurations. The changes primarily address the handling of padding tokens during mean pooling and introduce new test cases to validate the consistency of embeddings generated by the model across devices and configurations.

### Improvements to embedding computation:

* [`src/lobster/model/_ume.py`](diffhunk://#diff-d191d7b2a2e81ee87c07961e919192007358d2a98a5e396cfabba050db44f479L443-R470): Updated the embedding computation logic to use an attention mask for excluding padding tokens from mean pooling. This ensures accurate aggregation by masking out padding tokens, preventing them from affecting the computed embeddings. Additionally, safeguards were added to handle mismatched sequence lengths between the attention mask and embeddings.

### Enhanced test coverage:

* [`tests/lobster/model/test__ume.py`](diffhunk://#diff-3f96a9813768980bff629197578aa724adfac50736c7589ea5e18c7dcc9874adR295-R414): Added a new test method `test_flash_attention_consistency_across_devices` to validate the consistency of embeddings generated with flash attention (GPU) and non-flash attention (CPU). The test includes various modalities (e.g., amino acid, nucleotide, SMILES) and checks cosine similarity to ensure embeddings are nearly identical (>99.9% similarity). It also tests consistency between padded and unpadded architectures.

## Type of Change
- [X] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [X] Tests pass locally
- [X] Added new tests for new functionality
- [X] Updated existing tests if needed

## Checklist
- [X] Code follows style guidelines
- [X] Self-review completed
- [X] Documentation updated if needed
- [X] No breaking changes (or clearly documented)