### PR TITLE
Fix UME embedding dtype mismatch

### DIFF
--- a/src/lobster/model/_ume.py
+++ b/src/lobster/model/_ume.py
@@ -457,7 +457,7 @@ class UME(L.LightningModule):
                 attention_mask = torch.cat([attention_mask, padding], dim=1)
 
         # Convert to float and add dimension for broadcasting: (batch, seq_len, 1)
-        mask = attention_mask.float().unsqueeze(-1)
+        mask = attention_mask.to(dtype=embeddings.dtype).unsqueeze(-1)
 
         if aggregate:
             # Apply mask and compute mean only over actual tokens


### PR DESCRIPTION
## Description
Make UME embeddings coming out of `UME.embed` match the current dtype of the model. Currently, embeddings are being returned as `torch.float32` even when the model has been cast to `bfloat16`.

Also includes a test for embedding output matching the expected dtype. Test fails without the change, test passes with the change.

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## Testing
- [x] Tests pass locally
- [x] Added new tests for new functionality
- [ ] Updated existing tests if needed

## Checklist
- [ ] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated if needed
- [x] No breaking changes (or clearly documented)