### PR TITLE
Fix output formatting for PEER evaluation callback

### DIFF
--- a/src/lobster/callbacks/_peer_utils.py
+++ b/src/lobster/callbacks/_peer_utils.py
@@ -18,18 +18,19 @@ logger = logging.getLogger(__name__)
 
 def convert_numpy_to_python(obj):
     """Recursively convert NumPy scalars to Python types for clean YAML formatting."""
-    if isinstance(obj, dict):
-        return {key: convert_numpy_to_python(value) for key, value in obj.items()}
-    elif isinstance(obj, (list, tuple)):
-        return [convert_numpy_to_python(item) for item in obj]
-    elif isinstance(obj, np.integer):
-        return int(obj)
-    elif isinstance(obj, np.floating):
-        return float(obj)
-    elif isinstance(obj, np.bool_):
-        return bool(obj)
-    else:
-        return obj
+    match obj:
+        case dict():
+            return {key: convert_numpy_to_python(value) for key, value in obj.items()}
+        case list() | tuple():
+            return [convert_numpy_to_python(item) for item in obj]
+        case np.integer():
+            return int(obj)
+        case np.floating():
+            return float(obj)
+        case np.bool_():
+            return bool(obj)
+        case _:
+            return obj
 
 
 def get_peer_task_metric(task: PEERTask) -> str:

--- a/src/lobster/constants/_peer_tasks.py
+++ b/src/lobster/constants/_peer_tasks.py
@@ -32,9 +32,9 @@ class PEERTask(str, Enum):
     PPIAFFINITY = "ppiaffinity"
     YEASTPPI = "yeastppi"
     # Structure prediction tasks
-    FOLD = "fold"
+    FOLD = "fold"  # Remote homology detection (superfamily holdout, used in the PEER paper)
     PROTEINNET = "proteinnet"
-    SECONDARY_STRUCTURE = "secondarystructure"
+    SECONDARY_STRUCTURE = "secondarystructure"  # CB513 benchmark, as used in the PEER paper
 
 
 # Map tasks to their categories

--- a/tests/lobster/callbacks/test__peer_evaluation_callback.py
+++ b/tests/lobster/callbacks/test__peer_evaluation_callback.py
@@ -168,7 +168,7 @@ class TestPEEREvaluationCallback:
         assert isinstance(test_datasets, dict)
         assert "test" in test_datasets
 
-        cache_key = str(PEERTask.STABILITY)
+        cache_key = PEERTask.STABILITY.value
         assert cache_key in callback.datasets
 
         _, ss_test_datasets = callback._get_task_datasets(PEERTask.SECONDARY_STRUCTURE)
@@ -327,7 +327,7 @@ class TestPEEREvaluationCallback:
                     assert "test" in results
                     assert "mse" in results["test"]
                     assert "r2" in results["test"]
-                    assert str(PEERTask.STABILITY) in callback.probes
+                    assert PEERTask.STABILITY.value in callback.probes
 
     @patch("lobster.callbacks._peer_evaluation_callback.PEEREvaluationCallback._evaluate_task")
     @patch("lobster.callbacks._peer_evaluation_callback.tqdm")


### PR DESCRIPTION
- Convert NumPy scalars to Python types for clean YAML formatting
- Use clean enum values (e.g., 'bindingdb') instead of 'PEERTask.BINDINGDB'
- Move convert_numpy_to_python utility to _peer_utils.py for reusability
- Ensure consistent markdown formatting with other evaluation callbacks

This makes PEER evaluation results display cleanly in evaluation reports, matching the format of CALM and MoleculeACE callbacks.

## Description
Brief description of changes made

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Testing
- [x] Tests pass locally
- [ ] Added new tests for new functionality
- [ ] Updated existing tests if needed

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [x] Documentation updated if needed
- [x] No breaking changes (or clearly documented)