### PR TITLE
Change all instances of beignet Transform to lobster Transform

### DIFF
--- a/src/lobster/callbacks/_linear_probe_callback.py
+++ b/src/lobster/callbacks/_linear_probe_callback.py
@@ -5,7 +5,7 @@ from typing import Literal
 import lightning as L
 import numpy as np
 import torch
-from beignet.transforms import Transform
+from lobster.transforms import Transform
 from lightning.pytorch.callbacks import Callback
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.multioutput import MultiOutputClassifier

--- a/src/lobster/datasets/_m3_20m_dataset.py
+++ b/src/lobster/datasets/_m3_20m_dataset.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 import pandas
 import pooch
-from beignet.transforms import Transform
+from lobster.transforms import Transform
 from torch.utils.data import Dataset
 
 from lobster.datasets._huggingface_iterable_dataset import HuggingFaceIterableDataset

--- a/src/lobster/datasets/_moleculeace_dataset.py
+++ b/src/lobster/datasets/_moleculeace_dataset.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas
 import pooch
 import torch
-from beignet.transforms import Transform
+from lobster.transforms import Transform
 from torch import Tensor
 from torch.utils.data import Dataset
 


### PR DESCRIPTION
## Description
Addressing #157, changed the import `from beignet.transforms import Transform` to `from lobster.transforms import Transform` for consistency.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring

## Testing
- [x] Tests pass locally
- [ ] Added new tests for new functionality
- [ ] Updated existing tests if needed

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated if needed
- [x] No breaking changes (or clearly documented)