### PR TITLE
Handle ESM wrapper's embed method in peer callback

### DIFF
--- a/src/lobster/callbacks/_peer_evaluation_callback.py
+++ b/src/lobster/callbacks/_peer_evaluation_callback.py
@@ -67,7 +67,13 @@ class PEEREvaluationCallback(LinearProbeCallback):
     Reference: Guo et al. (2023) "PEER: A Comprehensive and Multi-Task Benchmark for
     Protein Sequence Understanding" https://arxiv.org/abs/2206.02096
 
-    Supports both tokenizer-based models (UMETokenizerTransform) and sequence-based models (ESM).
+    Model compatibility:
+    - UME models: Use requires_tokenization=True (default)
+    - ESM models: Use requires_tokenization=False
+    
+    Both UME and ESM models must implement:
+    - embed_sequences(sequences, modality, aggregate) method
+    - embed(inputs, aggregate) method (UME for tokenized inputs, ESM for raw sequences)
     """
 
     def __init__(
@@ -121,6 +127,9 @@ class PEEREvaluationCallback(LinearProbeCallback):
                 modality="amino_acid",
                 max_length=max_length,
             )
+        elif not requires_tokenization and transform_fn is None:
+            # For models that don't require tokenization (ESM), use identity transform
+            transform_fn = lambda x: x  # Pass sequences through unchanged
 
         super().__init__(
             transform_fn=transform_fn,
@@ -204,6 +213,8 @@ class PEEREvaluationCallback(LinearProbeCallback):
     ) -> Tensor:
         """Process inputs and extract embeddings using UME's built-in embedding methods.
 
+        This method is compatible with UME and also supports ESM models.
+
         Parameters
         ----------
         pl_module : L.LightningModule
@@ -222,15 +233,24 @@ class PEEREvaluationCallback(LinearProbeCallback):
             Embeddings tensor of shape (batch_size, hidden_size) if aggregate=True
             or (batch_size, seq_len, hidden_size) if aggregate=False
         """
-        # Handle raw sequences directly using UME's embed_sequences method
+        # Handle raw sequences directly using embed_sequences method
         if isinstance(inputs, (str, list)) and not isinstance(inputs, dict):
-            # Use UME's embed_sequences method directly for raw sequences
+            # Use embed_sequences method directly for raw sequences (UME and ESM)
             return pl_module.embed_sequences(inputs, modality=modality, aggregate=aggregate)
 
-        # Handle tokenized inputs using UME's embed method
+        # Handle tokenized inputs using embed method
         elif isinstance(inputs, (dict, BatchEncoding)) and "input_ids" in inputs:
-            # For tokenized inputs, use UME's embed method
-            return pl_module.embed(inputs, aggregate=aggregate)
+            # For tokenized inputs, use embed method (UME)
+            try:
+                return pl_module.embed(inputs, aggregate=aggregate)
+            except NotImplementedError:
+                # ESM doesn't support tokenized inputs, so extract sequences if available
+                if hasattr(inputs, "original_sequence"):
+                    sequences = inputs.original_sequence
+                    return pl_module.embed_sequences(sequences, modality=modality, aggregate=aggregate)
+                else:
+                    raise ValueError(f"Model {type(pl_module)} doesn't support tokenized inputs "
+                                   f"and no original sequences available in the data")
 
         # Handle mixed case - try to extract sequences if possible
         else:


### PR DESCRIPTION
## Description
The ESM wrapper's embed method expects sequences, not tokenized inputs. The PEER evals, however, previously assumed embed took in tokenized inputs. Updating peer callback to account for this

## Type of Change
- [x] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
