### PR TITLE
Refactor/strict bool for use flash attn

### DIFF
--- a/src/lobster/evaluation/dgeb_adapter.py
+++ b/src/lobster/evaluation/dgeb_adapter.py
@@ -116,7 +116,7 @@ class UMEAdapterDGEB(BioSeqTransformer):
                 logger.info("Flash attention detected and enabled for better performance")
             else:
                 # Requested, but either CUDA unavailable or flash attention unavailable
-                logger.info("Flash attention requested but not available - flash attention will be disabled")
+                logger.warning("Flash attention requested but not available - flash attention will be disabled")
         else:
             logger.info("Flash attention disabled")
 

--- a/src/lobster/evaluation/dgeb_adapter.py
+++ b/src/lobster/evaluation/dgeb_adapter.py
@@ -42,8 +42,11 @@ class UMEAdapterDGEB(BioSeqTransformer):
         Pooling strategy. One of "mean", "max", "cls", "last".
     modality : Literal["protein", "dna"], default="protein"
         Biological modality for the sequences.
-    use_flash_attn : bool | None, default=None
-        Whether to use flash attention. If None, determined by device availability.
+    use_flash_attn : bool, default=True
+        Whether to use flash attention.
+        If True: flash attention will be enabled only if the device is "cuda" and
+        flash attention is available.
+        If False: flash attention is disabled.
     """
 
     def __init__(
@@ -57,7 +60,7 @@ class UMEAdapterDGEB(BioSeqTransformer):
         batch_size: int = 128,
         pool_type: str = "mean",
         modality: Literal["protein", "dna"] = "protein",
-        use_flash_attn: bool | None = None,
+        use_flash_attn: bool = True,
     ):
         logger.info(f"Initializing UMEAdapterDGEB with model_name={model_name}, modality={modality}")
         if devices is None:
@@ -106,19 +109,16 @@ class UMEAdapterDGEB(BioSeqTransformer):
 
         # Determine flash attention usage
         use_flash_attn = False
-        if self._use_flash_attn is not None:
-            # User explicitly specified flash attention preference
-            use_flash_attn = self._use_flash_attn
-            if use_flash_attn and device == "cpu":
-                logger.warning("Flash attention requested but using CPU - flash attention will be disabled")
-                use_flash_attn = False
-        elif device == "cuda":
-            # Auto-detect flash attention availability on GPU
-            use_flash_attn = self._check_flash_attention_available()
-            if use_flash_attn:
+        if self._use_flash_attn:
+            # Enable flash attention only if CUDA is available and flash attention is available
+            if device == "cuda" and self._check_flash_attention_available():
+                use_flash_attn = True
                 logger.info("Flash attention detected and enabled for better performance")
             else:
-                logger.info("Flash attention not available - using standard attention")
+                # Requested, but either CUDA unavailable or flash attention unavailable
+                logger.info("Flash attention requested but not available - flash attention will be disabled")
+        else:
+            logger.info("Flash attention disabled")
 
         return device, use_flash_attn
 

--- a/src/lobster/evaluation/dgeb_mock_adapter.py
+++ b/src/lobster/evaluation/dgeb_mock_adapter.py
@@ -37,7 +37,7 @@ class MockUMEAdapterDGEB(BioSeqTransformer):
         Pooling strategy (used for metadata only).
     modality : Literal["protein", "dna"], default="protein"
         Biological modality for the sequences.
-    use_flash_attn : bool | None, default=None
+    use_flash_attn : bool, default=False
         Whether to use flash attention (unused in mock implementation).
     embed_dim : int, default=768
         Embedding dimension for the random embeddings.
@@ -58,7 +58,7 @@ class MockUMEAdapterDGEB(BioSeqTransformer):
         batch_size: int = 128,
         pool_type: str = "mean",
         modality: Literal["protein", "dna"] = "protein",
-        use_flash_attn: bool | None = None,
+        use_flash_attn: bool = False,
         embed_dim: int = 768,
         num_layers: int = 12,
         seed: int = 42,

--- a/src/lobster/evaluation/dgeb_mock_runner.py
+++ b/src/lobster/evaluation/dgeb_mock_runner.py
@@ -54,7 +54,7 @@ def run_mock_evaluation(
     output_dir: str = "dgeb_mock_results",
     batch_size: int = 32,
     max_seq_length: int = 1024,
-    use_flash_attn: bool | None = None,
+    use_flash_attn: bool = False,
     l2_norm: bool = False,
     pool_type: str = "mean",
     devices: list[int] | None = None,
@@ -78,7 +78,7 @@ def run_mock_evaluation(
         Batch size for encoding (unused in mock implementation).
     max_seq_length : int, default=1024
         Maximum sequence length.
-    use_flash_attn : bool | None, default=None
+    use_flash_attn : bool, default=False
         Whether to use flash attention (unused in mock implementation).
     l2_norm : bool, default=False
         Whether to L2-normalize embeddings.
@@ -391,9 +391,6 @@ def main():
     # Set up logging
     setup_logging(args.log_level)
 
-    # Handle flash attention flag
-    use_flash_attn = args.use_flash_attn if args.use_flash_attn else None
-
     # Run evaluation
     try:
         results_summary = run_mock_evaluation(
@@ -403,7 +400,7 @@ def main():
             output_dir=args.output_dir,
             batch_size=args.batch_size,
             max_seq_length=args.max_seq_length,
-            use_flash_attn=use_flash_attn,
+            use_flash_attn=args.use_flash_attn,
             l2_norm=args.l2_norm,
             pool_type=args.pool_type,
             devices=args.devices,

--- a/src/lobster/evaluation/dgeb_runner.py
+++ b/src/lobster/evaluation/dgeb_runner.py
@@ -46,7 +46,7 @@ def run_evaluation(
     output_dir: str = "dgeb_results",
     batch_size: int = 32,
     max_seq_length: int = 1024,
-    use_flash_attn: bool | None = None,
+    use_flash_attn: bool = True,
     l2_norm: bool = False,
     pool_type: str = "mean",
     devices: list[int] | None = None,
@@ -68,7 +68,7 @@ def run_evaluation(
         Batch size for encoding.
     max_seq_length : int, default=1024
         Maximum sequence length.
-    use_flash_attn : bool | None, default=None
+    use_flash_attn : bool, default=True
         Whether to use flash attention.
     l2_norm : bool, default=False
         Whether to L2-normalize embeddings.
@@ -498,9 +498,6 @@ def main():
     # Set up logging
     setup_logging(args.log_level)
 
-    # Handle flash attention flag
-    use_flash_attn = args.use_flash_attn if args.use_flash_attn else None
-
     # Run evaluation
     try:
         results_summary = run_evaluation(
@@ -510,7 +507,7 @@ def main():
             output_dir=args.output_dir,
             batch_size=args.batch_size,
             max_seq_length=args.max_seq_length,
-            use_flash_attn=use_flash_attn,
+            use_flash_attn=args.use_flash_attn,
             l2_norm=args.l2_norm,
             pool_type=args.pool_type,
             devices=args.devices,

--- a/src/lobster/model/_ume.py
+++ b/src/lobster/model/_ume.py
@@ -1053,7 +1053,7 @@ class UME(L.LightningModule):
         cls,
         checkpoint_path: str,
         *args,
-        use_flash_attn: bool | None = None,
+        use_flash_attn: bool = True,
         device: str | None = None,
         **kwargs,
     ) -> "UME":
@@ -1067,8 +1067,9 @@ class UME(L.LightningModule):
         ----------
         checkpoint_path : str
             Path to the checkpoint file.
-        use_flash_attn : bool | None, optional
-            Whether to use flash attention. If None, will be determined based on device.
+        use_flash_attn : bool, default=True
+            Whether to attempt using flash attention. If True: flash attention will be enabled only if the device is "cuda".
+            If False: flash attention is disabled and no check is performed.
         device : str | None, optional
             Device to load the model on ("cpu" or "cuda"). If None, will be determined automatically.
         *args
@@ -1095,9 +1096,10 @@ class UME(L.LightningModule):
         else:
             device = "cuda" if torch.cuda.is_available() else "cpu"
 
-        # Determine flash attention setting
-        if use_flash_attn is None:
-            use_flash_attn = device == "cuda"
+        # Resolve flash attention setting
+        if use_flash_attn and device != "cuda":
+            logger.warning("Flash attention requested but CUDA is unavailable - flash attention will be disabled.")
+            use_flash_attn = False
 
         # Configure model based on device
         model_kwargs = kwargs.pop("model_kwargs", {})
@@ -1125,7 +1127,7 @@ class UME(L.LightningModule):
         model_name: Literal["ume-mini-base-12M", "ume-small-base-90M", "ume-medium-base-480M", "ume-large-base-740M"],
         *,
         device: str | None = None,
-        use_flash_attn: bool | None = None,
+        use_flash_attn: bool = True,
         cache_dir: str | None = None,
         **kwargs,
     ) -> "UME":
@@ -1148,8 +1150,9 @@ class UME(L.LightningModule):
             - "ume-mini-base-12M" -> loads UME_mini with default checkpoint
         device : str | None, optional
             Device to load the model on ("cpu" or "cuda"). If None, will be determined automatically.
-        use_flash_attn : bool | None, optional
-            Whether to use flash attention. If None, will be determined based on device.
+        use_flash_attn : bool, default=True
+            Whether to attempt using flash attention. If True: flash attention will be enabled only if the device is "cuda".
+            If False: flash attention is disabled and no check is performed.
         cache_dir : str | None, optional
             Directory to cache downloaded models. If None, uses 'models/ume' in current directory.
         **kwargs

--- a/tests/lobster/model/test__ume.py
+++ b/tests/lobster/model/test__ume.py
@@ -519,7 +519,7 @@ class TestUME:
             local_filename="ume-mini-base-12M-20250711-061718.ckpt",
             load_func=UME.load_from_checkpoint,
             device=None,
-            use_flash_attn=None,
+            use_flash_attn=True,
         )
 
         assert result == mock_model


### PR DESCRIPTION
## Description
Replaced all instances of the tri-state Boolean `use_flash_attn: bool | None = None` to be strictly a `bool`. Addresses #170.

## `model/_ume.py`
- Previously, `use_flash_attn = None` implied that the user had no preference, and flash attention would be enabled automatically if `device == "cuda"`.
- This logic is now replaced with an explicit default: `use_flash_attn: bool = True`
- If `use_flash_attn` is `True` but flash attention is not available (`device != "cuda"`), a warning is logged and `use_flash_attn` is overridden to `False`.

### `tests/model/test__ume.py`
- Updated `test_from_pretrained` to reflect that `use_flash_attn = True` is now the default.

## `evaluation/dgeb_*.py`
- In `dgeb_adapter.py` and `dgeb_runner.py`, the default is now `use_flash_attn = True`
     - If flash attention is unavailable, it is set to `False` and a warning is logged.
     - The adapter uses the more robust `_check_flash_attention_available` method from `UMEAdapterDGEB` to check whether flash attention can be enabled (compared to just `device != "cuda"`)
- In `dgeb_mock_adapter.py` and `dgeb_mock_runner.py`, the default is set to `False` as flash attention is explicitly unused in the mock implementation.

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
