### PR TITLE
set boto logging to critical

### DIFF
--- a/src/lobster/cmdline/evaluate.py
+++ b/src/lobster/cmdline/evaluate.py
@@ -6,9 +6,12 @@ import torch
 from omegaconf import DictConfig, OmegaConf
 
 from lobster.evaluation import evaluate_model_with_callbacks
+from lobster.cmdline.utils import set_botocore_logging_level
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+set_botocore_logging_level()
 
 
 @hydra.main(config_path="../hydra_config", config_name="evaluate", version_base=None)

--- a/src/lobster/cmdline/train.py
+++ b/src/lobster/cmdline/train.py
@@ -6,9 +6,10 @@ from lightning.pytorch.utilities import rank_zero_only
 from omegaconf import DictConfig, OmegaConf
 
 import wandb
-from lobster.cmdline._utils import instantiate_callbacks
+from lobster.cmdline.utils import instantiate_callbacks, set_botocore_logging_level
 
 dotenv.load_dotenv(".env")
+set_botocore_logging_level()
 
 
 @hydra.main(version_base=None, config_path="../hydra_config", config_name="train")

--- a/src/lobster/cmdline/utils.py
+++ b/src/lobster/cmdline/utils.py
@@ -1,4 +1,5 @@
 import hydra
+import logging
 from lightning.pytorch.callbacks import Callback
 from lightning.pytorch.plugins.precision.precision_plugin import PrecisionPlugin
 from omegaconf import DictConfig
@@ -40,3 +41,9 @@ def instantiate_plugins(plugins_cfg: DictConfig) -> list[Callback]:
             plugins.append(hydra.utils.instantiate(cb_conf))
 
     return plugins
+
+
+def set_botocore_logging_level(level: int = logging.CRITICAL) -> None:
+    for name in logging.Logger.manager.loggerDict.keys():
+        if name in ("boto", "urllib3", "s3transfer", "boto3", "botocore", "nose"):
+            logging.getLogger(name).setLevel(level)


### PR DESCRIPTION
## Description
boto logs are very noisy and this PR adds an option to set them to a specified level

## Type of Change
- [ ] Bug fix
- [ ] New feature  
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
