### PR TITLE
Clarify forward() type signatures and add docstrings

### DIFF
--- a/src/lobster/model/_clm.py
+++ b/src/lobster/model/_clm.py
@@ -162,21 +162,27 @@ class LobsterPCLM(pl.LightningModule):
         return loss, logits
 
     def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass of the model for ONNX compiling.
+        """Extract stacked hidden states from all decoder layers.
+
+        Runs a forward pass through the causal language model backbone and
+        returns hidden representations from every layer, stacked along a new
+        dimension. This method is intended for ONNX export and direct
+        inference; it does **not** compute the causal-LM loss.
 
         Parameters
         ----------
-        input_ids: torch.Tensor
-            The input tensor.
-        attention_mask: torch.Tensor
-            The attention mask tensor.
+        input_ids : torch.Tensor
+            Token IDs of shape ``(batch_size, sequence_length)``.
+        attention_mask : torch.Tensor
+            Binary mask of shape ``(batch_size, sequence_length)`` where ``1``
+            indicates a real token and ``0`` indicates padding.
 
         Returns
         -------
         torch.Tensor
-            The output tensor.
-
+            Hidden states of shape
+            ``(batch_size, num_layers, sequence_length, hidden_size)``
+            where ``num_layers`` includes the embedding layer.
         """
         preds = self.model(input_ids=input_ids, attention_mask=attention_mask, output_hidden_states=True)
         hidden_states = preds["hidden_states"]  # hidden reps (B, L, H)

--- a/src/lobster/model/_mgm.py
+++ b/src/lobster/model/_mgm.py
@@ -213,21 +213,27 @@ class LobsterMGM(pl.LightningModule):
         return loss, logging_dicts
 
     def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass of the model for ONNX compiling.
+        """Extract stacked hidden states from all encoder layers.
+
+        Runs a forward pass through the multi-granularity model backbone and
+        returns hidden representations from every layer, stacked along a new
+        dimension. This method is intended for ONNX export and direct
+        inference; it does **not** compute the masked-LM loss.
 
         Parameters
         ----------
-        input_ids: torch.Tensor
-            The input tensor.
-        attention_mask: torch.Tensor
-            The attention mask tensor.
+        input_ids : torch.Tensor
+            Token IDs of shape ``(batch_size, sequence_length)``.
+        attention_mask : torch.Tensor
+            Binary mask of shape ``(batch_size, sequence_length)`` where ``1``
+            indicates a real token and ``0`` indicates padding.
 
         Returns
         -------
         torch.Tensor
-            The output tensor.
-
+            Hidden states of shape
+            ``(batch_size, num_layers, sequence_length, hidden_size)``
+            where ``num_layers`` includes the embedding layer.
         """
         preds = self.model(input_ids=input_ids, attention_mask=attention_mask, output_hidden_states=True)
         hidden_states = preds["hidden_states"]  # hidden reps (B, L, H)

--- a/src/lobster/model/_mlm.py
+++ b/src/lobster/model/_mlm.py
@@ -218,21 +218,27 @@ class LobsterPMLM(pl.LightningModule):
         return loss, logging_dicts
 
     def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
-        """
-        Forward pass of the model for ONNX compiling.
+        """Extract stacked hidden states from all encoder layers.
+
+        Runs a forward pass through the masked language model backbone and
+        returns hidden representations from every layer, stacked along a new
+        dimension. This method is intended for ONNX export and direct
+        inference; it does **not** compute the masked-LM loss.
 
         Parameters
         ----------
-        input_ids: torch.Tensor
-            The input tensor.
-        attention_mask: torch.Tensor
-            The attention mask tensor.
+        input_ids : torch.Tensor
+            Token IDs of shape ``(batch_size, sequence_length)``.
+        attention_mask : torch.Tensor
+            Binary mask of shape ``(batch_size, sequence_length)`` where ``1``
+            indicates a real token and ``0`` indicates padding.
 
         Returns
         -------
         torch.Tensor
-            The output tensor.
-
+            Hidden states of shape
+            ``(batch_size, num_layers, sequence_length, hidden_size)``
+            where ``num_layers`` includes the embedding layer.
         """
         preds = self.model(
             input_ids=input_ids,

--- a/src/lobster/model/gen_ume/_gen_ume_sequence_structure_encoder.py
+++ b/src/lobster/model/gen_ume/_gen_ume_sequence_structure_encoder.py
@@ -166,7 +166,38 @@ class UMESequenceStructureEncoderModule(nn.Module):
         return_auxiliary_tasks: bool = False,
         timesteps: Tensor | None = None,
         **kwargs,
-    ) -> Tensor:
+    ) -> dict[str, Tensor | tuple[Tensor, ...]]:
+        """Encode paired sequence and structure tokens through the backbone.
+
+        Embeds sequence and structure tokens separately, concatenates them
+        with an optional conditioning signal, and passes the result through
+        the NeoBERT encoder. Output logits for both sequence and structure
+        are projected from the last hidden state.
+
+        Parameters
+        ----------
+        sequence_input_ids : Tensor
+            Sequence token IDs of shape ``(batch_size, seq_len)``.
+        structure_input_ids : Tensor
+            Structure token IDs of shape ``(batch_size, seq_len)``.
+        position_ids : Tensor
+            Residue position indices of shape ``(batch_size, seq_len)``.
+            Currently unused internally but accepted for API consistency.
+        attention_mask : Tensor
+            Binary mask of shape ``(batch_size, seq_len)``.
+        conditioning_tensor : Tensor | None
+            Optional conditioning signal for guided generation.
+        return_auxiliary_tasks : bool
+            If *True*, run auxiliary task heads and include their outputs.
+        timesteps : Tensor | None
+            Diffusion timesteps, passed through to the backbone.
+
+        Returns
+        -------
+        dict[str, Tensor | tuple[Tensor, ...]]
+            Dictionary with ``"last_hidden_state"``, ``"sequence_logits"``,
+            ``"structure_logits"``, and optionally auxiliary task outputs.
+        """
         sequence_output = self.sequence_embedding(sequence_input_ids)
         structure_output = self.structure_embedding(structure_input_ids)
         conditioning_output = self.conditioning_embedding(conditioning_tensor)

--- a/src/lobster/model/gen_ume/_gen_ume_sequence_structure_encoder_lightning_module.py
+++ b/src/lobster/model/gen_ume/_gen_ume_sequence_structure_encoder_lightning_module.py
@@ -315,7 +315,32 @@ class UMESequenceStructureEncoderLightningModule(LightningModule):
         conditioning_tensor: Tensor,
         timesteps: dict[str, Tensor] | None = None,
     ) -> dict[str, Tensor]:
-        """Forward pass of the model, for inference."""
+        """Denoise interpolated sequence and structure tokens.
+
+        Intended for inference. Passes noised tokens through the encoder to
+        predict the clean (unmasked) sequence and structure tokens.
+
+        Parameters
+        ----------
+        x_t : dict[str, Tensor]
+            Noised token tensors with keys ``"sequence_tokens"`` and
+            ``"structure_tokens"``, each of shape ``(batch_size, seq_len)``.
+        mask : Tensor
+            Attention mask of shape ``(batch_size, seq_len)``.
+        residue_index : Tensor
+            Residue position indices of shape ``(batch_size, seq_len)``.
+        conditioning_tensor : Tensor
+            Conditioning signal for guided generation.
+        timesteps : dict[str, Tensor] | None
+            Diffusion timesteps with keys ``"sequence_tokens"`` and
+            ``"structure_tokens"``, each of shape ``(batch_size,)``. Expanded
+            internally to match sequence length.
+
+        Returns
+        -------
+        dict[str, Tensor]
+            Predicted unmasked tokens from the encoder.
+        """
         if timesteps is not None:
             timesteps = timesteps.copy()
             # expand to be same length as x_t e.g from B to B,L

--- a/src/lobster/model/neobert/neobert_module.py
+++ b/src/lobster/model/neobert/neobert_module.py
@@ -49,14 +49,43 @@ class NeoBERTModule(nn.Module):
     def forward(
         self,
         input_ids: Tensor,
-        position_ids: Tensor = None,
-        max_seqlen: int = None,
-        cu_seqlens: Tensor = None,
-        attention_mask: Tensor = None,
+        position_ids: Tensor | None = None,
+        max_seqlen: int | None = None,
+        cu_seqlens: Tensor | None = None,
+        attention_mask: Tensor | None = None,
         output_hidden_states: bool = False,
         output_attentions: bool = False,
         **kwargs,
-    ) -> dict:
+    ) -> dict[str, Tensor | tuple[Tensor, ...]]:
+        """Run the NeoBERT encoder and return the last hidden state.
+
+        Parameters
+        ----------
+        input_ids : Tensor
+            Token IDs of shape ``(batch_size, sequence_length)``.
+        position_ids : Tensor | None
+            Position indices of shape ``(batch_size, sequence_length)``.
+            Inferred from ``input_ids`` when *None*.
+        max_seqlen : int | None
+            Maximum sequence length in the batch, used with packed/unpadded
+            inputs together with ``cu_seqlens``.
+        cu_seqlens : Tensor | None
+            Cumulative sequence lengths for packed inputs.
+        attention_mask : Tensor | None
+            Binary mask of shape ``(batch_size, sequence_length)`` where ``1``
+            indicates a real token and ``0`` indicates padding.
+        output_hidden_states : bool
+            If *True*, include all intermediate hidden states in the output.
+        output_attentions : bool
+            If *True*, include attention weights in the output.
+
+        Returns
+        -------
+        dict[str, Tensor | tuple[Tensor, ...]]
+            Dictionary with ``"last_hidden_state"`` of shape
+            ``(batch_size, sequence_length, hidden_size)``, and optionally
+            ``"hidden_states"`` and ``"attentions"``.
+        """
         output = self.model(
             input_ids=input_ids,
             position_ids=position_ids,

--- a/src/lobster/model/ume2/ume_interaction.py
+++ b/src/lobster/model/ume2/ume_interaction.py
@@ -109,7 +109,28 @@ class UMEInteraction(nn.Module):
         inputs1: dict[str, Tensor],
         inputs2: dict[str, Tensor],
         use_cross_attention: bool = True,
-    ):
+    ) -> tuple[Tensor, Tensor]:
+        """Encode two molecular inputs and optionally mix via cross-attention.
+
+        Parameters
+        ----------
+        inputs1 : dict[str, Tensor]
+            First input dictionary with keys ``"modality"``, ``"input_ids"``
+            of shape ``(batch_size, seq_len_1)``, and ``"attention_mask"``
+            of shape ``(batch_size, seq_len_1)``.
+        inputs2 : dict[str, Tensor]
+            Second input dictionary with the same keys as *inputs1*, where
+            shapes may differ in sequence length.
+        use_cross_attention : bool
+            If *True*, apply the cross-attention interaction module to the
+            hidden states before returning.
+
+        Returns
+        -------
+        tuple[Tensor, Tensor]
+            Hidden states for each input, both of shape
+            ``(batch_size, seq_len, hidden_size)``.
+        """
         encoder1 = self.molecular_encoders[inputs1["modality"]]
         encoder2 = self.molecular_encoders[inputs2["modality"]]
 

--- a/src/lobster/model/ume2/ume_sequence_encoder.py
+++ b/src/lobster/model/ume2/ume_sequence_encoder.py
@@ -83,7 +83,27 @@ class UMESequenceEncoderModule(nn.Module):
 
     def forward(
         self, input_ids: Tensor, attention_mask: Tensor, return_auxiliary_tasks: bool = False, **kwargs
-    ) -> Tensor:
+    ) -> dict[str, Tensor | tuple[Tensor, ...]]:
+        """Encode token sequences through the NeoBERT backbone.
+
+        Parameters
+        ----------
+        input_ids : Tensor
+            Token IDs of shape ``(batch_size, sequence_length)``.
+        attention_mask : Tensor
+            Binary mask of shape ``(batch_size, sequence_length)`` where ``1``
+            indicates a real token and ``0`` indicates padding.
+        return_auxiliary_tasks : bool
+            If *True*, run auxiliary task heads and include their outputs in
+            the returned dictionary.
+
+        Returns
+        -------
+        dict[str, Tensor | tuple[Tensor, ...]]
+            Dictionary with at least ``"last_hidden_state"`` of shape
+            ``(batch_size, sequence_length, hidden_size)``. Auxiliary task
+            outputs are added when ``return_auxiliary_tasks`` is *True*.
+        """
         output = self.neobert(input_ids=input_ids, attention_mask=attention_mask, **kwargs)
 
         if self.auxiliary_tasks is not None and return_auxiliary_tasks:


### PR DESCRIPTION
# References and relevant issues

Closes #172

## Summary

- Add NumPy-style docstrings with parameter descriptions and shape annotations across 8 model files
- Fix incorrect return type annotations (e.g., `forward()` returning a `dict` but annotated as `Tensor`)
- No logic changes — annotations and docstrings only

## Test plan

- [ ] `ruff check` passes
- [ ] Existing tests pass (no behavior changes)


🤖 Generated with [Claude Code](https://claude.com/claude-code)